### PR TITLE
fix(data-location): data location set to default for function params/…

### DIFF
--- a/playground.ford
+++ b/playground.ford
@@ -2,7 +2,6 @@ contract Playground;
 
 let owner = address();
 let s = "hello Ford!";
-
 let b = false;
 let y = 100000000000000;
 let y0 = u8(200);
@@ -32,10 +31,10 @@ def lambda {
     }
 }
 
-def what (x: u8, y: u8, addr: address): u8 {
+def what (_x: u8, _y: u8, _addr: address): u8 {
 
     // revert(x * y > 100, 'Too high. Reverting');
-    // emit('Multiplied', x, y);
+    // emit('Multiplied', _x, _y);
 
-    return x * y;
+    return _x * _y;
 }

--- a/playground.spec.yaml
+++ b/playground.spec.yaml
@@ -14,6 +14,3 @@ defs:
       - name: y
         type: u8
     returnType: bool
-
-
-

--- a/src/controller.js
+++ b/src/controller.js
@@ -8,7 +8,7 @@ const Controller = (programFile, specFile) => {
   const f = fs.readFileSync(programFile).toString()
   const parser = new Parser()
   const inputAst = parser.parse(f);
-  console.log(JSON.stringify(inputAst, null, 2))
+  // console.log(JSON.stringify(inputAst, null, 2))
 
   // metadata
   const y = fs.readFileSync(specFile, 'utf8').toString()
@@ -16,7 +16,7 @@ const Controller = (programFile, specFile) => {
 
   const transpiler = new Transpiler(inputAst, metadata)
   const outputAst = transpiler.transpile()
-  console.log(JSON.stringify(outputAst, null, 2))
+  // console.log(JSON.stringify(outputAst, null, 2))
 
   const codegen = new Codegen()
   const solidityCode = codegen.generate(outputAst)

--- a/src/transpiler/model/sol_FunctionParameterDeclaration.js
+++ b/src/transpiler/model/sol_FunctionParameterDeclaration.js
@@ -18,7 +18,7 @@ function Sol_FunctionParameterDeclaration(node, metadata) {
     scope: currentScope++,
     src: source,
     stateVariable: false,
-    storageLocation: 'memory',
+    storageLocation: 'default', // TODO: handle other data-location (for structs, mappings, arrays)
     typeDescriptions: {},
     typeName: {
       /* TODO: stateMutability */


### PR DESCRIPTION
data location can not be `memory` for parameter types that are not in: structs, mappings or arrays.
We set the `storageLocation` to default for now with a TODO