### PR TITLE
feat(func-visibility): enable defs visibility markers

### DIFF
--- a/playground.ford
+++ b/playground.ford
@@ -1,9 +1,10 @@
 contract Playground;
 
 let owner = address();
+let addr = address("0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c");
+
 let s = "hello Ford!";
 let b = false;
-let y = 100000000000000;
 let y0 = u8(200);
 let y1 = u16(2000);
 let y2 = u32(20000);
@@ -11,24 +12,26 @@ let y3 = u64(200000);
 let y4 = u128(2000000);
 let y5 = u256(20000000);
 
-let x = 10;
 let x0 = i8(10);
 let x1 = i16(100);
 let x2 = i32(1000);
-let addr = address("0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c");
 let x3 = i8(-2);
 let x4 = i64(-1100002);
 
-def lambda {
-    let z = 100;
-    let b2 = false;
-    let st = "local!";
-    let localAddr = address("0xCA35b7d915458EF540aDe6068dFe2F44E8fa733c");
-    let ab = i32(-3478923);
+// Public
+def somePublicDef {}
 
+// External
+def* lambda {
     for let k = 0 to 10 {}
 }
 
-def symbols (^ x: string, ∞ m: address->u256, y: i16): u8 {
+// Private
+def- symbols (^ x: string, ∞ m: address->u256, y: i16): u8 {
     return 1;
+}
+
+// Payable
+def$ payableDef (amount: i16) {
+    return 10;
 }

--- a/playground.spec.yaml
+++ b/playground.spec.yaml
@@ -6,11 +6,7 @@ defs:
     # visibility: external
     # params: []
     # returnType: null
-  - name: contains
+  - name: symbols
     stateMutability: pure
-    params:
-      - name: x
-        type: listU8
-      - name: y
-        type: u8
+    visibility: internal
     returnType: bool

--- a/src/controller.js
+++ b/src/controller.js
@@ -21,6 +21,7 @@ const Controller = (programFile, specFile) => {
   const codegen = new Codegen()
   const solidityCode = codegen.generate(outputAst)
   console.log(solidityCode)
+
 }
 
 Controller(process.argv[2], process.argv[3])

--- a/src/parser/Tokenizer.js
+++ b/src/parser/Tokenizer.js
@@ -26,7 +26,12 @@ const Spec = [
   [/^\bnull\b/, 'null'],
   [/^\bfor\b/, 'for'],
   [/^\bto\b/, 'to'],
-  [/^\bdef\b/, 'def'],
+
+  [/^\bdef\$(?!\w)/, 'DEF_PAYABLE'],
+  [/^\bdef\*(?!\w)/, 'DEF_EXTERNAL'],
+  [/^\bdef\-(?!\w)/, 'DEF_PRIVATE'],
+  [/^\bdef\b/, 'DEF'],
+
   [/^\breturn\b/, 'return'],
   [/^\bcontract\b/, 'contract'],
 
@@ -80,6 +85,7 @@ class Tokenizer {
     const string = this._string.slice(this._cursor)
     for (const [regexp, tokenType] of Spec) {
       const tokenValue = this._match(regexp, string)
+
       // could not match this regexp -> continuing to next regexp
       if (tokenValue == null) { continue }
 

--- a/src/transpiler/model/FunctionDeclaration.js
+++ b/src/transpiler/model/FunctionDeclaration.js
@@ -63,9 +63,9 @@ function FunctionDeclaration(node, metadata) {
     },
     scope: currentScope++,
     src: '0:0:0',
-    stateMutability: stateMutability || 'nonpayable',
+    stateMutability: node.stateMutability,
     virtual: false,
-    visibility: visibility || 'public'
+    visibility: node.visibility
   }
 
   // handle function parameters list


### PR DESCRIPTION
Visibility markers for defs

```
// Public
def somePublicDef {}

// External
def* lambda {
    for let k = 0 to 10 {}
}

// Private
def- symbols (^ x: string, ∞ m: address->u256, y: i16): u8 {
    return 1;
}

// Payable
def$ payableDef (amount: i16) {
    return 10;
}
```